### PR TITLE
Fix/27 concurrent modification

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,12 @@ val store = Store(
 	automaticallySkipRepeats = false)
 ```
 
+### Subscribe/Unsubscribe during `newState`
+
+Under the hood ReKotlin uses a [`CopyOnWriteArrayList`](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/CopyOnWriteArrayList.html) to manage subscriptions (see [PR 29](https://github.com/ReKotlin/ReKotlin/pull/29) for more details). This implementation detail means that the number of concurrent writes to the subscriptions should be less than the number of concurrent reads.
+
+In terms of using the library this means that un/subscribing may incur a performance overhead if done during `newState` in store subscribers. We recommend to restrict this usage (concurrent write while reading subscriptions) as much as possible, i.e. avoid `subscribe` or `unsubscribe` in calls to `newState`.
+
 ## Contributing
 
 Please format your code using ``kotlinFormatter.xml`` file from [here](Docs/kotlinFormatter.xml)

--- a/src/main/kotlin/org/rekotlin/Store.kt
+++ b/src/main/kotlin/org/rekotlin/Store.kt
@@ -1,5 +1,7 @@
 package org.rekotlin
 
+import java.util.concurrent.CopyOnWriteArrayList
+
 /**
  * Created by Taras Vozniuk on 31/07/2017.
  * Copyright © 2017 GeoThings. All rights reserved.
@@ -54,7 +56,7 @@ class Store<State: StateType> (
                 middleware(dispatch, getState)(dispatchFunction)
             })
 
-    val subscriptions: MutableList<SubscriptionBox<State, Any>> = arrayListOf()
+    val subscriptions: MutableList<SubscriptionBox<State, Any>> = CopyOnWriteArrayList()
 
     private var isDispatching = false
 

--- a/src/main/kotlin/org/rekotlin/Store.kt
+++ b/src/main/kotlin/org/rekotlin/Store.kt
@@ -54,7 +54,7 @@ class Store<State: StateType> (
                 middleware(dispatch, getState)(dispatchFunction)
             })
 
-    val subscriptions: MutableList<SubscriptionBox<State, Any>> = mutableListOf()
+    val subscriptions: MutableList<SubscriptionBox<State, Any>> = arrayListOf()
 
     private var isDispatching = false
 

--- a/src/test/kotlin/org/rekotlin/StoreSubscriptionTests.kt
+++ b/src/test/kotlin/org/rekotlin/StoreSubscriptionTests.kt
@@ -209,4 +209,33 @@ internal class StoreSubscriptionTests {
         store.unsubscribe(blockSubscriptions)
         assertEquals(0, store.subscriptions.count())
     }
+
+    @Test
+    fun testSubscribeDuringOnNewState() {
+        // setup
+        val reducer = TestValueStringReducer()
+        val store = Store(reducer = reducer::handleAction, state = TestStringAppState())
+
+        val subscribeA = ViewSubscriberTypeA(store)
+        store.subscribe(subscribeA)
+
+        // execute
+        store.dispatch(SetValueStringAction("subscribe"))
+    }
+
+    @Test
+    fun testUnSubscribeDuringOnNewState() {
+        // setup
+        val reducer = TestValueStringReducer()
+        val store = Store(reducer = reducer::handleAction, state = TestStringAppState())
+
+        val subscriberA = ViewSubscriberTypeA(store)
+        val subscriberC = ViewSubscriberTypeC()
+        store.subscribe(subscriberA)
+        store.subscribe(subscriberC)
+
+        // execute
+        store.dispatch(SetValueStringAction("unsubscribe"))
+    }
+
 }

--- a/src/test/kotlin/org/rekotlin/TestFakes.kt
+++ b/src/test/kotlin/org/rekotlin/TestFakes.kt
@@ -114,6 +114,38 @@ internal class TestStoreSubscriber<T> : StoreSubscriber<T> {
     }
 }
 
+/**
+ * A subscriber contains another sub-subscribers [StoreSubscriber], which could be subscribe/unsubscribe at some point
+ */
+internal class ViewSubscriberTypeA(var store: Store<TestStringAppState>) : StoreSubscriber<TestStringAppState> {
+    private val viewB by lazy { ViewSubscriberTypeB(store) }
+    private val viewC by lazy { ViewSubscriberTypeC() }
+
+    override fun newState(state: TestStringAppState) {
+        when(state.testValue){
+            "subscribe" -> store.subscribe(viewC)
+            "unsubscribe" ->  store.unsubscribe(viewB)
+            else -> println(state.testValue)
+        }
+    }
+}
+
+internal class ViewSubscriberTypeB(store: Store<TestStringAppState>) : StoreSubscriber<TestStringAppState> {
+    init {
+        store.subscribe(this)
+    }
+
+    override fun newState(state: TestStringAppState) {
+        // do nothing
+    }
+}
+
+internal class ViewSubscriberTypeC : StoreSubscriber<TestStringAppState> {
+    override fun newState(state: TestStringAppState) {
+        // do nothing
+    }
+}
+
 internal class DispatchingSubscriber(var store: Store<TestAppState>) : StoreSubscriber<TestAppState> {
 
     override fun newState(state: TestAppState) {


### PR DESCRIPTION
As described in #27 any call to `subscribe` or `unsubscribe` from a `newState` would create a `ConcurrentModificationException` because the list of `subscriptions` was modified (by un/subscribe) while iterating over it (from the setter of `_state`).

By using a `CopyOnWriteArrayList` the iteration over the original list finishes (without modification) while any future access of `subscription` reflects the mutation.

Fixes #27