### PR TITLE
ReKotlin Contravariant Store Subscriber

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     testCompile "org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version"
+    testCompile "org.mockito:mockito-core:3.3.3"
     testRuntime "org.junit.jupiter:junit-jupiter-engine:$junit_jupiter_version"
     testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_launcher"
 }

--- a/src/main/kotlin/org/rekotlin/Store.kt
+++ b/src/main/kotlin/org/rekotlin/Store.kt
@@ -72,7 +72,7 @@ class Store<State : StateType>(
         this._state?.let { this._state = state } ?: this.dispatch(ReKotlinInit())
     }
 
-    override fun <S : StoreSubscriber<State>> subscribe(subscriber: S) {
+    override fun <S : StoreSubscriber<in State>> subscribe(subscriber: S) {
 
         // if subscribersAutomaticallySkipsRepeat is set
         // skipRepeats will be applied with kotlin structural equality
@@ -85,7 +85,7 @@ class Store<State : StateType>(
         }
     }
 
-    override fun <SelectedState, S : StoreSubscriber<SelectedState>> subscribe(
+    override fun <SelectedState, S : StoreSubscriber<in SelectedState>> subscribe(
         subscriber: S,
         transform: ((Subscription<State>) -> Subscription<SelectedState>)?
     ) {

--- a/src/main/kotlin/org/rekotlin/StoreType.kt
+++ b/src/main/kotlin/org/rekotlin/StoreType.kt
@@ -46,7 +46,7 @@ interface StoreType<State : StateType> : DispatchingStoreType {
      * state in this store changes.
      * @param subscriber: Subscriber that will receive store updates
      */
-    fun <S : StoreSubscriber<State>> subscribe(subscriber: S)
+    fun <S : StoreSubscriber<in State>> subscribe(subscriber: S)
 
     /**
      * Subscribes the provided subscriber to this store.
@@ -59,7 +59,7 @@ interface StoreType<State : StateType> : DispatchingStoreType {
      * transformed subscription. Subscriptions can be transformed to only select a subset of the
      * state, or to skip certain state updates.
      */
-    fun <SelectedState, S : StoreSubscriber<SelectedState>> subscribe(
+    fun <SelectedState, S : StoreSubscriber<in SelectedState>> subscribe(
         subscriber: S,
         transform: ((Subscription<State>) -> Subscription<SelectedState>)?
     )

--- a/src/main/kotlin/org/rekotlin/Subscription.kt
+++ b/src/main/kotlin/org/rekotlin/Subscription.kt
@@ -32,10 +32,10 @@ package org.rekotlin
  * subscription and passes any values that come through this subscriptions to the subscriber.
  *
  */
-class SubscriptionBox<State, SelectedState>(
+class SubscriptionBox<State, in SelectedState>(
     private val originalSubscription: Subscription<State>,
     transformedSubscription: Subscription<SelectedState>?,
-    val subscriber: StoreSubscriber<SelectedState>
+    val subscriber: StoreSubscriber<in SelectedState>
 ) where State : StateType {
 
     // hoping to mimic swift weak reference

--- a/src/test/kotlin/org/rekotlin/StoreSubscriberContravariantTests.kt
+++ b/src/test/kotlin/org/rekotlin/StoreSubscriberContravariantTests.kt
@@ -1,0 +1,43 @@
+package org.rekotlin
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations
+
+class StoreSubscriberContravariantTests {
+
+    @Mock
+    lateinit var subscriber: StoreSubscriber<BaseAppState>
+
+    @BeforeEach
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+    }
+
+    @Test
+    fun subscriberCanBeCovariantTypeToStoreStateType() {
+        // Arrange
+        val appState = AppState()
+        val store = Store(AppStateReducer(), appState, emptyList(), false)
+        // Act
+        // A StoreSubscriber of a super type should be an acceptable type to be passed into a Store.
+        store.subscribe(subscriber)
+        store.dispatch(AppAction())
+
+        // Assert
+        verify(subscriber, times(2)).newState(safeEq(appState))
+    }
+
+    interface BaseAppState : StateType
+    internal class AppAction : Action
+    internal data class AppState(val userName: String = "") : BaseAppState
+    internal class AppStateReducer : Reducer<AppState> {
+        override fun invoke(action: Action, state: AppState?): AppState = state ?: AppState()
+    }
+
+    private fun <T : Any> safeEq(value: T): T = eq(value) ?: value
+}


### PR DESCRIPTION
Under the current setup we cannot create a StoreSubscriber for the supertype of our State. This is due to the fact that StoreSubscriber is a consumer of the State and without use of  `in` declaration site-variance the type resolves to the concrete version of the StateType and will not allow it's super type to be a valid type.
 
I wrote a [test](src/test/kotlin/org/rekotlin/StoreSubscriberContravariantTests.kt) that verifies that this will work functionally. This doesn't test the actual change which would be caught at compile time because the removal of `in` would make the test class not legal. 